### PR TITLE
add: header to link to 2022's site

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,6 +858,9 @@
         </div>
         <div class="container-fluid col-sm-7" style="overflow-x: visible;margin-right: -20px">
             <ul class="navbar-nav">
+              <li class="nav-item" style = "margin-left:20%;">
+                <a class="nav-link navbartext" href="https://2022.garudahacks.com">2022</a>
+              </li>
                 <li class="nav-item" style = "margin-left:20%;">
                   <a class="nav-link navbartext" href="#">Home</a>
                 </li>

--- a/mobileport.html
+++ b/mobileport.html
@@ -489,7 +489,8 @@
 				</button>
 				<div class="collapse navbar-collapse" id="collapsibleNavbar">
 					<ul class="navbar-nav">
-						<li><a class="dropdown-item navbartext" href="#about" style="margin-left:20px;margin-top:30px">About</a></li>
+						<li><a class="dropdown-item navbartext" href="https://2022.garudahacks.com" style="margin-left:20px;margin-top:30px">2022</a></li>
+						<li><a class="dropdown-item navbartext" href="#about" style="margin-left:20px;">About</a></li>
 						<li><a class="dropdown-item navbartext" href="#how-it-works" style="margin-left:20px">How It Works</a></li>
 						<li><a class="dropdown-item navbartext" href="#project-track" style="margin-left:20px">Tracks</a></li>
 						<li><a class="dropdown-item navbartext" href="#prize-pool" style="margin-left:20px">Prizes</a></li>


### PR DESCRIPTION
This pull request includes updates to the navigation menus in both `index.html` and `mobileport.html` to add a link to the 2022 Garuda Hacks event.

Changes to navigation menus:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R861-R863): Added a new navigation item linking to the 2022 Garuda Hacks event.
* [`mobileport.html`](diffhunk://#diff-45cfeaa49e8c118e5911067dedbf135bffdc5233890bde03f081c4afff259429L492-R493): Added a new dropdown item linking to the 2022 Garuda Hacks event and adjusted the margin for the "About" link.